### PR TITLE
Removed period after URL

### DIFF
--- a/sandiegopythonbot.py
+++ b/sandiegopythonbot.py
@@ -60,7 +60,7 @@ class SanDiegoPythonBot(irc.bot.SingleServerIRCBot):
         logger.debug(u'Received command {} from {}'.format(cmd, nick))
 
         if cmd == "help":
-            c.privmsg(self.channel, u"I'm a bot. My source code is here: https://github.com/pythonsd/ircbot. You're welcome to send a pull request to change my behavior.")
+            c.privmsg(self.channel, u"I'm a bot. My source code is here: https://github.com/pythonsd/ircbot You're welcome to send a pull request to change my behavior.")
         elif cmd == "welcome":
             self.do_welcome(c, nick)
         elif cmd.startswith('kick'):


### PR DESCRIPTION
Some IRC clients incorrectly included the period in the link.
